### PR TITLE
Package with `uv` + auto-detect PR from current branch by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+coderabbit_review_extractor.egg-info

--- a/README.md
+++ b/README.md
@@ -7,34 +7,76 @@ Convert CodeRabbit GitHub PR reviews into clean, LLM-friendly text for AI-assist
 CodeRabbit provides excellent automated code review feedback, but it's designed for human consumption in GitHub's web interface. This tool extracts that feedback and formats it specifically for AI coding agents (Claude, ChatGPT, etc.) to automatically apply suggestions.
 
 Perfect for:
+
 - 🤖 **AI-assisted development workflows**
-- 🔄 **Automated code improvement pipelines** 
+- 🔄 **Automated code improvement pipelines**
 - 📝 **Converting review feedback to actionable prompts**
 - 🚀 **Streamlining the code review → implementation cycle**
 
 ## Quick Start
 
 ```bash
-# Basic usage - latest review only (recommended)
-python3 extract-coderabbit-feedback.py obra/lace/278
+# Auto-detect PR for current branch (no arguments needed!)
+coderabbit-extract
+
+# Or specify a PR explicitly
+coderabbit-extract obra/lace/278
+coderabbit-extract https://github.com/owner/repo/pull/123
 
 # All reviews (for complex analysis)
-python3 extract-coderabbit-feedback.py obra/lace/255 --all-reviews
+coderabbit-extract obra/lace/255 --all-reviews
 
 # Get help
-python3 extract-coderabbit-feedback.py --help
+coderabbit-extract --help
 ```
 
 ## Installation
 
 ### Requirements
+
 - **GitHub CLI** (`gh`) installed and authenticated
-- **Python 3.6+** 
+- **Python 3.10+**
 - **beautifulsoup4** package
 
 ### Install Dependencies
 
-**Option 1: Direct usage (recommended)**
+**Option 1: uv tool (recommended - global installation)**
+
+```bash
+# Clone the repository
+git clone https://github.com/obra/coderabbit-review-helper.git
+cd coderabbit-review-helper
+
+# Install globally with uv
+uv tool install .
+
+# Use from anywhere
+coderabbit-extract owner/repo/123
+
+# Update after pulling changes
+uv tool upgrade --reinstall coderabbit-review-extractor
+```
+
+**Option 2: uv sync (development/local usage)**
+
+```bash
+# Clone the repository
+git clone https://github.com/obra/coderabbit-review-helper.git
+cd coderabbit-review-helper
+
+# Sync dependencies and create virtual environment
+uv sync
+
+# Run with uv
+uv run extract-coderabbit-feedback.py owner/repo/123
+
+# Or activate the environment and run directly
+source .venv/bin/activate  # On Windows: .venv\Scripts\activate
+python extract-coderabbit-feedback.py owner/repo/123
+```
+
+**Option 3: Direct usage**
+
 ```bash
 # Clone and use directly
 git clone https://github.com/obra/coderabbit-review-helper.git
@@ -43,19 +85,22 @@ pip install --user beautifulsoup4
 ./extract-coderabbit-feedback.py owner/repo/123
 ```
 
-**Option 2: pip install (when published)**
+**Option 4: pip install (when published)**
+
 ```bash
 pip install coderabbit-review-extractor
 coderabbit-extract owner/repo/123
 ```
 
-**Option 3: pipx (isolated environment)**
+**Option 5: pipx (isolated environment)**
+
 ```bash
 pipx install coderabbit-review-extractor
 coderabbit-extract owner/repo/123
 ```
 
 ### Setup GitHub CLI
+
 ```bash
 # Install gh CLI
 brew install gh  # macOS
@@ -68,17 +113,21 @@ gh auth login
 ## Features
 
 ### 🎯 Smart Review Handling
+
+- **Auto-detect PR** - Automatically finds the PR for your current branch (no arguments needed!)
 - **Latest review by default** - Avoids overwhelming output from PRs with 20+ reviews
 - **File-organized output** - Groups all feedback by file for easy navigation
 - **Priority sorting** - AI-actionable items (🤖) appear first within each file
 
 ### 🤖 LLM-Optimized Format
+
 - **AI prompts prioritized** - Detailed implementation instructions when available
 - **Clean diffs** - Fallback for simple mechanical changes
 - **No redundancy** - Never shows both prompt AND diff for the same suggestion
 - **HTML-free output** - Stripped of GitHub web interface artifacts
 
 ### 📊 Example Output
+
 ```
 # CodeRabbit Review Feedback
 ========================================
@@ -93,12 +142,14 @@ gh auth login
 
 **Proposed prompt:**
 ```
+
 In packages/core/src/config/user-settings.ts around lines 13, 26, 52 and 68,
 replace the use of `any` with a concrete JSON-safe type: add a JsonValue
 (recursive union: string | number | boolean | null | JsonValue[] | { [key:
 string]: JsonValue }) and a UserSettings = Record<string, JsonValue> (or a more
 specific shape if known), then change private static cachedSettings, method
 parameters and return types to use UserSettings/JsonValue instead of any...
+
 ```
 
 ### 2. Lines 42: Consolidate ABOUTME comments
@@ -108,6 +159,7 @@ parameters and return types to use UserSettings/JsonValue instead of any...
 -// ABOUTME: Stores settings in ~/.lace/user-settings.json with no validation
 +// ABOUTME: Simple user settings manager for arbitrary JSON preferences stored in ~/.lace/user-settings.json (no validation)
 ```
+
 ```
 
 ## Options
@@ -121,6 +173,7 @@ parameters and return types to use UserSettings/JsonValue instead of any...
 - **`--debug`**: Show processing annotations to understand decisions
 
 ### Input Formats
+- **Auto-detect** (no arguments): Automatically uses PR for current branch
 - **Full URL**: `https://github.com/owner/repo/pull/123`
 - **Short format**: `owner/repo/123`
 
@@ -130,10 +183,13 @@ parameters and return types to use UserSettings/JsonValue instead of any...
 Some PRs accumulate dozens of reviews as code evolves:
 ```bash
 # Problem: 20 reviews = 300 comments across 36 files (overwhelming)
-python3 extract-coderabbit-feedback.py obra/lace/255 --all-reviews
+coderabbit-extract obra/lace/255 --all-reviews
 
-# Solution: Latest review only = 58 comments across 22 files (manageable) 
-python3 extract-coderabbit-feedback.py obra/lace/255
+# Solution: Latest review only = 58 comments across 22 files (manageable)
+coderabbit-extract obra/lace/255
+
+# Even simpler: Auto-detect if you're on the branch
+coderabbit-extract
 ```
 
 ### Custom Preambles for AI Critical Thinking
@@ -141,6 +197,7 @@ python3 extract-coderabbit-feedback.py obra/lace/255
 Create `~/.coderabbit-extractor` with custom text to prepend to output. Perfect for encouraging AI agents to think critically rather than blindly follow suggestions:
 
 **Example: Critical Evaluation Preamble**
+
 ```bash
 # Use the provided example
 cp example-preamble.txt ~/.coderabbit-extractor
@@ -159,18 +216,20 @@ EOF
 ```
 
 This "subterfuge" approach encourages AI agents to:
+
 - Question the validity of suggestions
 - Evaluate reviewer competence
 - Think independently about solutions
 - Avoid blind trust in automated tools
 
 ### Integration with AI Assistants
-```bash
-# With critical evaluation preamble
-python3 extract-coderabbit-feedback.py owner/repo/123 | claude-api
 
-# Direct application (less critical thinking)
-python3 extract-coderabbit-feedback.py owner/repo/123 | claude-api "Apply these suggestions"
+```bash
+# Auto-detect current branch PR with critical evaluation preamble
+coderabbit-extract | claude-api
+
+# Explicit PR with direct application (less critical thinking)
+coderabbit-extract owner/repo/123 | claude-api "Apply these suggestions"
 ```
 
 ## Output Format
@@ -178,17 +237,20 @@ python3 extract-coderabbit-feedback.py owner/repo/123 | claude-api "Apply these 
 The tool extracts and organizes three types of CodeRabbit feedback:
 
 ### 1. 🤖 AI-Actionable Items (Prioritized)
+
 - **Refactor suggestions** with detailed implementation prompts
 - **Cross-file changes** with scope guidance
 - **Security fixes** with context and alternatives
 - **Complex architectural changes** with step-by-step instructions
 
 ### 2. Nitpick Comments
+
 - **Style improvements** with simple diffs
 - **Best practice suggestions** with explanations
 - **Minor optimizations** with code examples
 
 ### 3. Outside Diff Range Comments  
+
 - **Issues outside the changed lines** with context
 - **Broader pattern suggestions** affecting multiple files
 - **Architectural recommendations** for consideration
@@ -196,15 +258,18 @@ The tool extracts and organizes three types of CodeRabbit feedback:
 ## Why This Format Works
 
 ### Problem-Focused vs Solution-Prescriptive
+
 - **Traditional diffs**: "Change A to B" (prescriptive)
 - **AI prompts**: "Problem X causes Y, consider approaches Z" (explanatory)
 
 ### Token Efficiency
+
 - **Eliminates redundancy** between descriptions, diffs, and prompts
 - **20% more concise** output while preserving critical information
 - **Priority-sorted** so AI focuses on most important items first
 
 ### Implementation Flexibility
+
 - **AI prompts** let agents find the best solution approach
 - **Simple diffs** provide precise guidance for mechanical changes
 - **Context preservation** for cross-file and multi-step changes
@@ -212,18 +277,24 @@ The tool extracts and organizes three types of CodeRabbit feedback:
 ## Development
 
 ### Debug Mode
+
 Use `--debug` to see processing decisions:
+
 ```bash
 python3 extract-coderabbit-feedback.py obra/lace/278 --debug
 ```
+
 Shows annotations like:
+
 ```
 <!-- DEBUG: has_prompt=True, has_diff=False, source=inline -->
 <!-- DEBUG: Showing prompt only, skipping description and diff -->
 ```
 
 ### Contributing
+
 This tool evolved through systematic agent feedback and iterative improvement:
+
 1. Initial extraction with HTML corruption issues
 2. Agent review identified formatting problems
 3. Step-by-step commits fixing each issue class

--- a/extract-coderabbit-feedback.py
+++ b/extract-coderabbit-feedback.py
@@ -9,12 +9,10 @@ __author__ = "Jesse Vincent"
 __license__ = "MIT"
 import argparse
 import json
-import os
 import re
 import subprocess
 import sys
 from pathlib import Path
-from urllib.parse import urlparse
 from typing import List, Dict, Any, Tuple, Optional
 from bs4 import BeautifulSoup
 import html
@@ -22,47 +20,52 @@ import html
 
 def load_preamble_config() -> Optional[str]:
     """Load custom preamble from dotfile."""
-    config_path = Path.home() / '.coderabbit-extractor'
-    
+    config_path = Path.home() / ".coderabbit-extractor"
+
     if config_path.exists():
         try:
-            return config_path.read_text(encoding='utf-8').strip()
+            return config_path.read_text(encoding="utf-8").strip()
         except Exception as e:
-            print(f"Warning: Could not read config file {config_path}: {e}", file=sys.stderr)
+            print(
+                f"Warning: Could not read config file {config_path}: {e}",
+                file=sys.stderr,
+            )
             return None
-    
+
     return None
 
 
 def parse_pr_input(input_str: str) -> str:
     """Parse PR URL or owner/repo/number format into a full GitHub PR URL."""
     input_str = input_str.strip()
-    
+
     # If it's already a full URL, return as-is
-    if input_str.startswith('https://github.com/'):
+    if input_str.startswith("https://github.com/"):
         return input_str
-    
+
     # Parse owner/repo/number format (e.g., "obra/lace/278")
-    parts = input_str.split('/')
+    parts = input_str.split("/")
     if len(parts) == 3:
         owner, repo, pr_num = parts
         return f"https://github.com/{owner}/{repo}/pull/{pr_num}"
-    
-    raise ValueError(f"Invalid PR format: {input_str}. Use 'owner/repo/number' or full URL")
+
+    raise ValueError(
+        f"Invalid PR format: {input_str}. Use 'owner/repo/number' or full URL"
+    )
 
 
 def extract_pr_info_from_url(pr_url: str) -> Tuple[str, str, int]:
     """Extract owner, repo, and PR number from GitHub PR URL."""
     # Parse URL like https://github.com/owner/repo/pull/123
-    if 'github.com' in pr_url:
-        parts = pr_url.replace('https://github.com/', '').split('/')
-        if len(parts) >= 4 and parts[2] == 'pull':
+    if "github.com" in pr_url:
+        parts = pr_url.replace("https://github.com/", "").split("/")
+        if len(parts) >= 4 and parts[2] == "pull":
             owner, repo, _, pr_number = parts[:4]
             try:
                 return owner, repo, int(pr_number)
             except ValueError:
                 raise ValueError(f"Invalid PR number: {pr_number}")
-    
+
     raise ValueError(f"Could not parse PR URL: {pr_url}")
 
 
@@ -70,13 +73,13 @@ def fetch_pr_reviews(pr_url: str) -> List[Dict[str, Any]]:
     """Fetch PR reviews using gh CLI."""
     try:
         result = subprocess.run(
-            ['gh', 'pr', 'view', pr_url, '--json', 'reviews'],
+            ["gh", "pr", "view", pr_url, "--json", "reviews"],
             capture_output=True,
             text=True,
-            check=True
+            check=True,
         )
         data = json.loads(result.stdout)
-        return data.get('reviews', [])
+        return data.get("reviews", [])
     except subprocess.CalledProcessError as e:
         print(f"Error fetching PR: {e.stderr}", file=sys.stderr)
         sys.exit(1)
@@ -90,21 +93,26 @@ def fetch_latest_commit_time(pr_url: str) -> Optional[str]:
     try:
         # Extract owner/repo/number from URL
         owner, repo, pr_number = extract_pr_info_from_url(pr_url)
-        
-        # Get commits from the PR
+
+        # Get commits from the PR (with pagination for PRs with >30 commits)
         result = subprocess.run(
-            ['gh', 'api', f'repos/{owner}/{repo}/pulls/{pr_number}/commits'],
+            [
+                "gh",
+                "api",
+                "--paginate",
+                f"repos/{owner}/{repo}/pulls/{pr_number}/commits",
+            ],
             capture_output=True,
             text=True,
-            check=True
+            check=True,
         )
         commits = json.loads(result.stdout)
-        
+
         if commits:
             # Get the most recent commit (last in the list)
             latest_commit = commits[-1]
-            return latest_commit['commit']['committer']['date']
-        
+            return latest_commit["commit"]["committer"]["date"]
+
         return None
     except Exception as e:
         print(f"Warning: Could not fetch latest commit time: {e}", file=sys.stderr)
@@ -115,21 +123,21 @@ def fetch_pr_inline_comments(pr_url: str) -> List[Dict[str, Any]]:
     """Fetch PR inline review comments using GitHub API via gh CLI."""
     try:
         # Extract owner/repo/number from URL
-        if 'github.com' in pr_url:
-            parts = pr_url.replace('https://github.com/', '').split('/')
-            if len(parts) >= 4 and parts[2] == 'pull':
+        if "github.com" in pr_url:
+            parts = pr_url.replace("https://github.com/", "").split("/")
+            if len(parts) >= 4 and parts[2] == "pull":
                 owner, repo, _, pr_number = parts[:4]
                 api_path = f"repos/{owner}/{repo}/pulls/{pr_number}/comments"
             else:
                 raise ValueError("Invalid GitHub PR URL format")
         else:
             raise ValueError("URL must be a GitHub PR URL")
-        
+
         result = subprocess.run(
-            ['gh', 'api', api_path],
+            ["gh", "api", "--paginate", api_path],
             capture_output=True,
             text=True,
-            check=True
+            check=True,
         )
         data = json.loads(result.stdout)
         return data if isinstance(data, list) else []
@@ -142,19 +150,25 @@ def fetch_pr_inline_comments(pr_url: str) -> List[Dict[str, Any]]:
         return []
 
 
-def fetch_review_threads_graphql(owner: str, repo: str, pr_number: int) -> List[Dict[str, Any]]:
-    """Fetch review threads with resolution status using GitHub GraphQL API."""
-    query = '''
-    query($owner: String!, $repo: String!, $prNumber: Int!) {
+def fetch_review_threads_graphql(
+    owner: str, repo: str, pr_number: int
+) -> List[Dict[str, Any]]:
+    """Fetch review threads with resolution status using GitHub GraphQL API with pagination."""
+    query = """
+    query($owner: String!, $repo: String!, $prNumber: Int!, $cursor: String) {
       repository(owner: $owner, name: $repo) {
         pullRequest(number: $prNumber) {
-          reviewThreads(first: 100) {
+          reviewThreads(first: 100, after: $cursor) {
             nodes {
               id
               isResolved
               resolvedBy {
                 login
               }
+              path
+              line
+              originalLine
+              startLine
               comments(first: 1) {
                 nodes {
                   body
@@ -165,55 +179,106 @@ def fetch_review_threads_graphql(owner: str, repo: str, pr_number: int) -> List[
                 }
               }
             }
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
           }
         }
       }
     }
-    '''
-    
-    variables = {
-        "owner": owner,
-        "repo": repo, 
-        "prNumber": pr_number
-    }
-    
+    """
+
     try:
-        # Use gh api to make GraphQL request
+        # Use gh api to make GraphQL request with pagination
         import json
-        result = subprocess.run([
-            'gh', 'api', 'graphql', 
-            '-F', f'owner={owner}',
-            '-F', f'repo={repo}', 
-            '-F', f'prNumber={pr_number}',
-            '-f', f'query={query}'
-        ], capture_output=True, text=True, check=True)
-        
-        data = json.loads(result.stdout)
-        
-        # Extract review threads
-        threads = data.get('data', {}).get('repository', {}).get('pullRequest', {}).get('reviewThreads', {}).get('nodes', [])
-        
+
+        all_threads = []
+        cursor = None
+        has_next_page = True
+        page_count = 0
+
+        while has_next_page:
+            page_count += 1
+
+            # Build command with cursor if available
+            cmd = [
+                "gh",
+                "api",
+                "graphql",
+                "-F",
+                f"owner={owner}",
+                "-F",
+                f"repo={repo}",
+                "-F",
+                f"prNumber={pr_number}",
+                "-f",
+                f"query={query}",
+            ]
+            if cursor:
+                cmd.extend(["-F", f"cursor={cursor}"])
+
+            result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+            data = json.loads(result.stdout)
+
+            # Extract review threads and pagination info
+            threads_data = (
+                data.get("data", {})
+                .get("repository", {})
+                .get("pullRequest", {})
+                .get("reviewThreads", {})
+            )
+            threads = threads_data.get("nodes", [])
+            page_info = threads_data.get("pageInfo", {})
+
+            all_threads.extend(threads)
+
+            has_next_page = page_info.get("hasNextPage", False)
+            cursor = page_info.get("endCursor")
+
+            if page_count > 1:
+                print(
+                    f"Fetched page {page_count} of review threads ({len(threads)} threads)",
+                    file=sys.stderr,
+                )
+
+        # Now filter all collected threads
+
         # Filter to only CodeRabbit threads and return as list of dicts
         coderabbit_threads = []
-        for thread in threads:
-            if thread and thread.get('comments', {}).get('nodes', []):
-                comment = thread['comments']['nodes'][0]
-                author_login = comment.get('author', {}).get('login', '')
+        for thread in all_threads:
+            if thread and thread.get("comments", {}).get("nodes", []):
+                comment = thread["comments"]["nodes"][0]
+                author_login = comment.get("author", {}).get("login", "")
                 # Check for both coderabbitai and coderabbitai[bot] formats
-                if author_login in ['coderabbitai', 'coderabbitai[bot]']:
-                    coderabbit_threads.append({
-                        'id': thread['id'],
-                        'isResolved': thread.get('isResolved', False),
-                        'resolvedBy': thread.get('resolvedBy', {}).get('login') if thread.get('resolvedBy') else None,
-                        'body': comment.get('body', ''),
-                        'createdAt': comment.get('createdAt', ''),
-                        'author': author_login
-                    })
-        
+                if author_login in ["coderabbitai", "coderabbitai[bot]"]:
+                    # Extract line range (handle both single line and ranges)
+                    start_line = thread.get("startLine")
+                    end_line = thread.get("line") or thread.get("originalLine")
+
+                    coderabbit_threads.append(
+                        {
+                            "id": thread["id"],
+                            "isResolved": thread.get("isResolved", False),
+                            "resolvedBy": thread.get("resolvedBy", {}).get("login")
+                            if thread.get("resolvedBy")
+                            else None,
+                            "body": comment.get("body", ""),
+                            "createdAt": comment.get("createdAt", ""),
+                            "author": author_login,
+                            "path": thread.get("path"),
+                            "line": end_line,
+                            "startLine": start_line,
+                        }
+                    )
+
         return coderabbit_threads
-        
+
     except subprocess.CalledProcessError as e:
-        print(f"Warning: Could not fetch review threads via GraphQL: {e.stderr}", file=sys.stderr)
+        print(
+            f"Warning: Could not fetch review threads via GraphQL: {e.stderr}",
+            file=sys.stderr,
+        )
         return []
     except json.JSONDecodeError as e:
         print(f"Warning: Could not parse GraphQL response: {e}", file=sys.stderr)
@@ -226,48 +291,54 @@ def fetch_review_threads_graphql(owner: str, repo: str, pr_number: int) -> List[
 def extract_coderabbit_reviews(reviews: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """Filter reviews to only CodeRabbit ones."""
     return [
-        review for review in reviews
-        if review.get('author', {}).get('login') == 'coderabbitai'
+        review
+        for review in reviews
+        if review.get("author", {}).get("login") == "coderabbitai"
     ]
 
 
 def filter_resolved_comments(comments: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """Filter out comments that have been marked as resolved."""
     return [
-        comment for comment in comments
-        if not is_comment_resolved(comment.get('body', ''))
+        comment
+        for comment in comments
+        if not is_comment_resolved(comment.get("body", ""))
     ]
 
 
 def filter_resolved_threads(threads: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """Filter out review threads that have been marked as resolved via GitHub's native resolution."""
-    return [
-        thread for thread in threads
-        if not thread.get('isResolved', False)
-    ]
+    return [thread for thread in threads if not thread.get("isResolved", False)]
 
 
 def filter_resolved_review_content(review_body: str) -> str:
     """Filter out resolved suggestions from review body content."""
     # Look for resolved comment patterns and remove them
     # This handles CodeRabbit's text-based resolution markers
-    
+
     # Pattern to match resolved comments within the review body
     # Look for sections that contain resolution markers
     resolved_patterns = [
         # Match individual comment sections that are resolved
-        r'<details>.*?✅\s*(?:Addressed|Resolved|Fixed|Completed).*?</details>',
+        r"<details>.*?✅\s*(?:Addressed|Resolved|Fixed|Completed).*?</details>",
         # Match line-specific resolved comments
-        r'`[^`]+`:\s*\*\*[^*]+\*\*.*?✅\s*(?:Addressed|Resolved|Fixed|Completed).*?(?=<details>|$)',
+        r"`[^`]+`:\s*\*\*[^*]+\*\*.*?✅\s*(?:Addressed|Resolved|Fixed|Completed).*?(?=<details>|$)",
     ]
-    
+
     filtered_body = review_body
     for pattern in resolved_patterns:
-        filtered_body = re.sub(pattern, '', filtered_body, flags=re.DOTALL | re.IGNORECASE)
-    
+        filtered_body = re.sub(
+            pattern, "", filtered_body, flags=re.DOTALL | re.IGNORECASE
+        )
+
     # Also remove any standalone resolution lines
-    filtered_body = re.sub(r'^.*✅\s*(?:Addressed|Resolved|Fixed|Completed).*$(\n)?', '', filtered_body, flags=re.MULTILINE | re.IGNORECASE)
-    
+    filtered_body = re.sub(
+        r"^.*✅\s*(?:Addressed|Resolved|Fixed|Completed).*$(\n)?",
+        "",
+        filtered_body,
+        flags=re.MULTILINE | re.IGNORECASE,
+    )
+
     return filtered_body.strip()
 
 
@@ -275,55 +346,62 @@ def is_comment_resolved(comment_body: str) -> bool:
     """Check if a comment has been marked as resolved/addressed."""
     # Look for resolution indicators in the comment body
     resolution_patterns = [
-        r'✅\s*Addressed\s+in\s+commit[s]?\s+[a-f0-9]+(?:\s+to\s+[a-f0-9]+)?',
-        r'✅\s*Resolved\s+in\s+commit[s]?\s+[a-f0-9]+(?:\s+to\s+[a-f0-9]+)?',
-        r'✅\s*Fixed\s+in\s+commit[s]?\s+[a-f0-9]+(?:\s+to\s+[a-f0-9]+)?',
-        r'✅\s*Completed\s+in\s+commit[s]?\s+[a-f0-9]+(?:\s+to\s+[a-f0-9]+)?',
-        r'\[x\]',  # Checkbox checked
-        r'\[X\]',  # Checkbox checked
+        r"✅\s*Addressed\s+in\s+commit[s]?\s+[a-f0-9]+(?:\s+to\s+[a-f0-9]+)?",
+        r"✅\s*Resolved\s+in\s+commit[s]?\s+[a-f0-9]+(?:\s+to\s+[a-f0-9]+)?",
+        r"✅\s*Fixed\s+in\s+commit[s]?\s+[a-f0-9]+(?:\s+to\s+[a-f0-9]+)?",
+        r"✅\s*Completed\s+in\s+commit[s]?\s+[a-f0-9]+(?:\s+to\s+[a-f0-9]+)?",
+        r"\[x\]",  # Checkbox checked
+        r"\[X\]",  # Checkbox checked
     ]
-    
+
     for pattern in resolution_patterns:
         if re.search(pattern, comment_body, re.IGNORECASE):
             return True
-    
+
     return False
 
 
-def extract_coderabbit_inline_comments(comments: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+def extract_coderabbit_inline_comments(
+    comments: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
     """Filter inline comments to only CodeRabbit ones."""
     return [
-        comment for comment in comments
-        if comment.get('user', {}).get('login') == 'coderabbitai[bot]'
+        comment
+        for comment in comments
+        if comment.get("user", {}).get("login") == "coderabbitai[bot]"
     ]
 
 
 def parse_review_type(body: str) -> str:
     """Determine the type of CodeRabbit review."""
-    if 'Actionable comments posted:' in body:
-        return 'ACTIONABLE_REVIEW'
-    elif 'walkthrough_start' in body and 'walkthrough_end' in body:
-        return 'WALKTHROUGH'
-    elif '<!-- This is an auto-generated comment: summarize by coderabbit.ai -->' in body:
-        return 'SUMMARY'
+    if "Actionable comments posted:" in body:
+        return "ACTIONABLE_REVIEW"
+    elif "walkthrough_start" in body and "walkthrough_end" in body:
+        return "WALKTHROUGH"
+    elif (
+        "<!-- This is an auto-generated comment: summarize by coderabbit.ai -->" in body
+    ):
+        return "SUMMARY"
     else:
-        return 'OTHER'
+        return "OTHER"
 
 
 def clean_html_artifacts(text: str) -> str:
     """Remove HTML comments and artifacts from text."""
     # Remove HTML comments
-    text = re.sub(r'<!--.*?-->', '', text, flags=re.DOTALL)
-    
+    text = re.sub(r"<!--.*?-->", "", text, flags=re.DOTALL)
+
     # Remove CodeRabbit warning blocks
-    text = re.sub(r'>\s*‼️\s*\*\*IMPORTANT\*\*.*?(?=\n\n|\n$)', '', text, flags=re.DOTALL)
-    
-    # Remove other quote block artifacts  
-    text = re.sub(r'>\s*Carefully review.*?(?=\n\n|\n$)', '', text, flags=re.DOTALL)
-    
+    text = re.sub(
+        r">\s*‼️\s*\*\*IMPORTANT\*\*.*?(?=\n\n|\n$)", "", text, flags=re.DOTALL
+    )
+
+    # Remove other quote block artifacts
+    text = re.sub(r">\s*Carefully review.*?(?=\n\n|\n$)", "", text, flags=re.DOTALL)
+
     # Remove empty lines that result from artifact removal
-    text = re.sub(r'\n\s*\n\s*\n', '\n\n', text)
-    
+    text = re.sub(r"\n\s*\n\s*\n", "\n\n", text)
+
     return text.strip()
 
 
@@ -331,38 +409,86 @@ def clean_diff_artifacts(diff: str) -> str:
     """Clean up diff artifacts and markers."""
     if not diff:
         return diff
-        
+
     # Remove @@ hunk markers - handle both @@ ... @@ and lone @@ lines
-    diff = re.sub(r'^@@.*?@@.*?\n', '', diff, flags=re.MULTILINE)  # Full hunk headers
-    diff = re.sub(r'^\s*@@\s*\n', '', diff, flags=re.MULTILINE)    # Lone @@ lines
-    
+    diff = re.sub(r"^@@.*?@@.*?\n", "", diff, flags=re.MULTILINE)  # Full hunk headers
+    diff = re.sub(r"^\s*@@\s*\n", "", diff, flags=re.MULTILINE)  # Lone @@ lines
+
     # Remove empty lines at start/end
     diff = diff.strip()
-    
+
     return diff
+
+
+def remove_details_sections(text: str) -> str:
+    """Remove verbose <details> sections containing analysis chains and script outputs.
+
+    Removes complete <details>...</details> blocks to filter out:
+    - Analysis/reasoning chains
+    - Script execution outputs
+    - Internal processing logs
+
+    This helps keep the output focused on actionable feedback.
+    """
+    # Remove all <details>...</details> blocks including nested content
+    text = re.sub(r"<details>.*?</details>", "", text, flags=re.DOTALL | re.IGNORECASE)
+
+    # Clean up any resulting excessive whitespace
+    text = re.sub(r"\n\s*\n\s*\n", "\n\n", text)
+
+    return text.strip()
+
+
+def extract_file_and_lines_from_body(body: str) -> Tuple[Optional[str], Optional[str]]:
+    """Extract file path and line range from CodeRabbit comment body.
+
+    CodeRabbit comments typically include file references like:
+    - "In <filepath> around line X"
+    - "In <filepath> around lines X to Y"
+    - "In <filepath> around lines X-Y"
+
+    Returns:
+        Tuple of (file_path, line_range) or (None, None) if not found
+    """
+    # Pattern to match file path references in CodeRabbit comments
+    # Matches: "In <filepath> around line(s) X" or "around lines X to Y" or "around lines X-Y"
+    file_pattern = r"In\s+([^\s]+(?:\.ts|\.tsx|\.js|\.jsx|\.py|\.java|\.go|\.rs|\.md|\.json|\.yaml|\.yml))\s+around\s+lines?\s+([\d\-to\s]+)"
+
+    match = re.search(file_pattern, body, re.IGNORECASE)
+    if match:
+        file_path = match.group(1).strip()
+        line_range = match.group(2).strip()
+
+        # Normalize line range format (convert "X to Y" to "X-Y")
+        line_range = re.sub(r"(\d+)\s+to\s+(\d+)", r"\1-\2", line_range)
+
+        return (file_path, line_range)
+
+    return (None, None)
 
 
 def extract_prompt_for_ai_agents(body: str) -> List[str]:
     """Extract 'Prompt for AI Agents' sections from review body."""
     prompts = []
-    
+
     # Pattern to find 🤖 Prompt for AI Agents sections
     # These appear to be in <summary> tags followed by clipboard content
     pattern = r'<summary>🤖 Prompt for AI Agents</summary>\s*<div[^>]*data-snippet-clipboard-copy-content="([^"]*)"'
     matches = re.findall(pattern, body, re.DOTALL)
-    
+
     for match in matches:
         # Decode HTML entities
-        clean_text = (match
-                     .replace('&lt;', '<')
-                     .replace('&gt;', '>')
-                     .replace('&amp;', '&')
-                     .replace('&quot;', '"')
-                     .replace('\\n', '\n')
-                     .strip())
+        clean_text = (
+            match.replace("&lt;", "<")
+            .replace("&gt;", ">")
+            .replace("&amp;", "&")
+            .replace("&quot;", '"')
+            .replace("\\n", "\n")
+            .strip()
+        )
         if clean_text:
             prompts.append(clean_text)
-    
+
     return prompts
 
 
@@ -372,334 +498,447 @@ def extract_prompt_for_ai_agents(body: str) -> List[str]:
 def parse_review_sections(body: str) -> Dict[str, Any]:
     """Parse different sections from CodeRabbit review body using HTML parsing."""
     sections = {}
-    
+
     # Extract actionable comments count from text
-    actionable_match = re.search(r'Actionable comments posted:\s*(\d+)', body)
+    actionable_match = re.search(r"Actionable comments posted:\s*(\d+)", body)
     if actionable_match:
-        sections['actionable_count'] = int(actionable_match.group(1))
-    
+        sections["actionable_count"] = int(actionable_match.group(1))
+
     # Parse HTML structure - but be careful not to mangle code content
     # Only use BeautifulSoup for extracting the <details> sections, then work with raw content
-    soup = BeautifulSoup(body, 'html.parser')
-    
+    soup = BeautifulSoup(body, "html.parser")
+
     # Find sections by looking for <details> elements with specific summary text
-    details_elements = soup.find_all('details')
-    
+    details_elements = soup.find_all("details")
+
     for details in details_elements:
-        summary = details.find('summary')
+        summary = details.find("summary")
         if not summary:
             continue
-            
+
         summary_text = summary.get_text(strip=True)
-        
+
         # Check for outside diff range comments (avoid emoji dependency)
-        if 'Outside diff range comments' in summary_text:
+        if "Outside diff range comments" in summary_text:
             # Extract count from summary text
-            count_match = re.search(r'\((\d+)\)', summary_text)
+            count_match = re.search(r"\((\d+)\)", summary_text)
             if count_match:
                 count = int(count_match.group(1))
-                blockquote = details.find('blockquote')
+                blockquote = details.find("blockquote")
                 if blockquote:
                     # Get all content inside the blockquote
                     content = str(blockquote)
-                    sections['outside_diff_comments'] = {'count': count, 'content': content}
-        
-        # Check for nitpick comments or duplicate comments  
-        elif 'Nitpick comments' in summary_text or 'Duplicate comments' in summary_text:
-            count_match = re.search(r'\((\d+)\)', summary_text)
+                    sections["outside_diff_comments"] = {
+                        "count": count,
+                        "content": content,
+                    }
+
+        # Check for nitpick comments or duplicate comments
+        elif "Nitpick comments" in summary_text or "Duplicate comments" in summary_text:
+            count_match = re.search(r"\((\d+)\)", summary_text)
             if count_match:
                 count = int(count_match.group(1))
                 # Instead of using BeautifulSoup's blockquote content (which mangles code),
                 # extract the raw content from the original body text
-                
+
                 # Find the position of this details section in the original body
-                details_start = body.find('Nitpick comments')
+                details_start = body.find("Nitpick comments")
                 if details_start != -1:
                     # Find where this section ends (next major section or end)
-                    section_markers = ['📜 Review details', '🔇 Additional comments', '</details>\n\n</details>']
+                    section_markers = [
+                        "📜 Review details",
+                        "🔇 Additional comments",
+                        "</details>\n\n</details>",
+                    ]
                     section_end = len(body)
-                    
+
                     for marker in section_markers:
                         marker_pos = body.find(marker, details_start)
                         if marker_pos != -1:
                             section_end = min(section_end, marker_pos)
-                    
+
                     # Extract the raw text content
                     raw_content = body[details_start:section_end]
-                    sections['nitpick_comments'] = {'count': count, 'content': raw_content}
-        
+                    sections["nitpick_comments"] = {
+                        "count": count,
+                        "content": raw_content,
+                    }
+
         # Check for review details (usually at the end)
-        elif 'Review details' in summary_text:
+        elif "Review details" in summary_text:
             # This section contains metadata, we might want it for context
-            blockquote = details.find('blockquote')
+            blockquote = details.find("blockquote")
             if blockquote:
                 content = str(blockquote)
-                sections['review_details'] = {'content': content}
-    
+                sections["review_details"] = {"content": content}
+
     # Extract AI prompts (look for specific patterns)
-    sections['ai_prompts'] = extract_prompt_for_ai_agents(body)
-    
+    sections["ai_prompts"] = extract_prompt_for_ai_agents(body)
+
     return sections
 
 
-def parse_file_level_comments(content: str, debug: bool = False) -> List[Dict[str, Any]]:
+def parse_file_level_comments(
+    content: str, debug: bool = False
+) -> List[Dict[str, Any]]:
     """Parse individual file-level comments from section content, avoiding HTML corruption."""
     comments = []
-    
+
     # Use regex to find file sections instead of BeautifulSoup to avoid HTML corruption
     # Pattern: <summary>filename (count)</summary><blockquote>content</blockquote></details>
-    file_pattern = r'<summary>([^<]+?)\s*\((\d+)\)</summary><blockquote>(.*?)</blockquote></details>'
+    file_pattern = r"<summary>([^<]+?)\s*\((\d+)\)</summary><blockquote>(.*?)</blockquote></details>"
     file_matches = list(re.finditer(file_pattern, content, re.DOTALL))
-    
+
     if debug:
-        print(f"DEBUG: parse_file_level_comments found {len(file_matches)} file sections", file=sys.stderr)
-    
+        print(
+            f"DEBUG: parse_file_level_comments found {len(file_matches)} file sections",
+            file=sys.stderr,
+        )
+
     for file_match in file_matches:
         file_path = file_match.group(1).strip()
         comment_count = int(file_match.group(2))
-        file_content = file_match.group(3)  # Raw blockquote content, not parsed by BeautifulSoup
-        
+        file_content = file_match.group(
+            3
+        )  # Raw blockquote content, not parsed by BeautifulSoup
+
         # Now parse line comments within this file content
         # Find line comment patterns: `16-24`: **Title**
-        line_pattern = r'`([^`]+)`:\s*\*\*(.*?)\*\*\s*\n\n(.*?)(?=\n\n`[^`]+`:\s*\*\*|\n\n---|\n\n</blockquote>|$)'
+        line_pattern = r"`([^`]+)`:\s*\*\*(.*?)\*\*\s*\n\n(.*?)(?=\n\n`[^`]+`:\s*\*\*|\n\n---|\n\n</blockquote>|$)"
         line_matches = list(re.finditer(line_pattern, file_content, re.DOTALL))
-        
+
         if debug:
-            print(f"DEBUG: File {file_path} has {len(line_matches)} line comments", file=sys.stderr)
-        
+            print(
+                f"DEBUG: File {file_path} has {len(line_matches)} line comments",
+                file=sys.stderr,
+            )
+
         for line_match in line_matches:
             line_range = line_match.group(1).strip()
-            title = line_match.group(2).strip() 
+            title = line_match.group(2).strip()
             content_block = line_match.group(3).strip()
-            
+
+            # Remove verbose <details> sections before processing
+            content_block = remove_details_sections(content_block)
+
             # Check if this looks like a line reference
-            if re.match(r'^[\d\-,\s]+$', line_range):
+            if re.match(r"^[\d\-,\s]+$", line_range):
                 # Extract description (everything before first code block)
                 description = content_block
                 code_diff = ""
-                
-                code_start = content_block.find('```')
+
+                code_start = content_block.find("```")
                 if code_start != -1:
                     description = content_block[:code_start].strip()
-                    
+
                     # Extract code diff from raw content (no BeautifulSoup mangling)
-                    diff_match = re.search(r'```diff\n(.*?)\n```', content_block, re.DOTALL)
+                    diff_match = re.search(
+                        r"```diff\n(.*?)\n```", content_block, re.DOTALL
+                    )
                     if diff_match:
                         code_diff = diff_match.group(1).strip()
                         # HTML decode only entities, don't let BeautifulSoup interpret as HTML
                         code_diff = html.unescape(code_diff)
-                        code_diff = clean_html_artifacts(code_diff)  # Remove any HTML comments in diffs
-                        code_diff = clean_diff_artifacts(code_diff)  # Clean up @@ markers and artifacts
-                
+                        code_diff = clean_html_artifacts(
+                            code_diff
+                        )  # Remove any HTML comments in diffs
+                        code_diff = clean_diff_artifacts(
+                            code_diff
+                        )  # Clean up @@ markers and artifacts
+
                 # Clean up description
-                description = clean_html_artifacts(description)  # Remove HTML comments first
+                description = clean_html_artifacts(
+                    description
+                )  # Remove HTML comments first
                 description_lines = []
-                for line in description.split('\n'):
+                for line in description.split("\n"):
                     line = line.strip()
-                    if line and not line.startswith('Also applies to:') and line != '---':
+                    if (
+                        line
+                        and not line.startswith("Also applies to:")
+                        and line != "---"
+                    ):
                         description_lines.append(line)
-                description = ' '.join(description_lines)
-                
-                comments.append({
-                    'file': file_path,
-                    'lines': line_range,
-                    'title': title,
-                    'description': description,
-                    'code_diff': code_diff
-                })
-    
+                description = " ".join(description_lines)
+
+                comments.append(
+                    {
+                        "file": file_path,
+                        "lines": line_range,
+                        "title": title,
+                        "description": description,
+                        "code_diff": code_diff,
+                    }
+                )
+
     return comments
 
 
-def group_comments_by_file(coderabbit_reviews: List[Dict[str, Any]], inline_comments: List[Dict[str, Any]] = None, debug: bool = False, include_resolved: bool = True) -> Dict[str, List[Dict[str, Any]]]:
+def group_comments_by_file(
+    coderabbit_reviews: List[Dict[str, Any]],
+    inline_comments: List[Dict[str, Any]] = None,
+    debug: bool = False,
+    include_resolved: bool = True,
+) -> Dict[str, List[Dict[str, Any]]]:
     """Group all comments by file for better organization."""
     file_groups = {}
-    
+
     # Process review body comments
     for review in coderabbit_reviews:
-        review_body = review['body']
-        
+        review_body = review["body"]
+
         # Filter out resolved content from review body if requested
         if not include_resolved:
             original_body = review_body
             review_body = filter_resolved_review_content(review_body)
             if debug and len(original_body) != len(review_body):
-                print(f"DEBUG: Filtered resolved content from review body (length: {len(original_body)} -> {len(review_body)})", file=sys.stderr)
-        
+                print(
+                    f"DEBUG: Filtered resolved content from review body (length: {len(original_body)} -> {len(review_body)})",
+                    file=sys.stderr,
+                )
+
         sections = parse_review_sections(review_body)
-        
+
         # Add outside diff comments
-        if 'outside_diff_comments' in sections:
-            outside_comments = parse_file_level_comments(sections['outside_diff_comments']['content'], debug)
+        if "outside_diff_comments" in sections:
+            outside_comments = parse_file_level_comments(
+                sections["outside_diff_comments"]["content"], debug
+            )
             for comment in outside_comments:
-                file_path = comment['file']
+                file_path = comment["file"]
                 if file_path not in file_groups:
                     file_groups[file_path] = []
-                comment['source'] = 'outside_diff'
+                comment["source"] = "outside_diff"
                 file_groups[file_path].append(comment)
-        
+
         # Add nitpick comments
-        if 'nitpick_comments' in sections:
-            nitpick_comments = parse_file_level_comments(sections['nitpick_comments']['content'], debug)
+        if "nitpick_comments" in sections:
+            nitpick_comments = parse_file_level_comments(
+                sections["nitpick_comments"]["content"], debug
+            )
             for comment in nitpick_comments:
-                file_path = comment['file']
+                file_path = comment["file"]
                 if file_path not in file_groups:
                     file_groups[file_path] = []
-                comment['source'] = 'nitpick'
+                comment["source"] = "nitpick"
                 file_groups[file_path].append(comment)
-    
+
     # Process inline comments
     if inline_comments:
         for comment in inline_comments:
-            file_path = comment.get('path', 'unknown')
-            line_num = comment.get('original_line', 'unknown')
-            
+            body = comment.get("body", "")
+
+            # Try to extract file path and line range from comment body
+            extracted_file, extracted_lines = extract_file_and_lines_from_body(body)
+
+            # Use extracted values if available, otherwise fall back to comment metadata
+            file_path = (
+                extracted_file if extracted_file else comment.get("path", "unknown")
+            )
+            line_num = comment.get("original_line", "unknown")
+            start_line = comment.get("start_line")
+
+            # Determine line range to display
+            if extracted_lines:
+                # Use extracted line range from body (highest priority)
+                line_range = extracted_lines
+            elif (
+                start_line
+                and line_num
+                and line_num != "unknown"
+                and line_num != 0
+                and start_line != line_num
+            ):
+                # Use GraphQL line range (start_line to line_num)
+                line_range = f"{start_line}-{line_num}"
+            elif line_num != "unknown" and line_num != 0:
+                # Single line from metadata
+                line_range = str(line_num)
+            else:
+                # No line info available
+                line_range = ""
+
             if file_path not in file_groups:
                 file_groups[file_path] = []
-                
+
             # Convert inline comment to standard format
-            body = comment.get('body', '')
-            comment_type = '🛠️ Refactor Suggestion' if '🛠️ Refactor suggestion' in body else 'Comment'
-            
+            comment_type = (
+                "🛠️ Refactor Suggestion"
+                if "🛠️ Refactor suggestion" in body
+                else "Comment"
+            )
+
             # Extract title from body
-            title_match = re.search(r'\*\*(.*?)\*\*', body)
+            title_match = re.search(r"\*\*(.*?)\*\*", body)
             title = title_match.group(1).strip() if title_match else "Suggestion"
-            
+
             # Extract description and diff
-            if '<details>' in body and 'Prompt for AI Agents' in body:
-                main_content = body.split('<details>')[0].strip()
+            if "<details>" in body and "Prompt for AI Agents" in body:
+                main_content = body.split("<details>")[0].strip()
             else:
                 main_content = body
-                
-            main_content = main_content.replace('_🛠️ Refactor suggestion_', '').strip()
+
+            # Remove verbose <details> sections
+            main_content = remove_details_sections(main_content)
+            main_content = main_content.replace("_🛠️ Refactor suggestion_", "").strip()
             main_content = clean_html_artifacts(main_content)
-            
+
             # Extract AI prompt
             ai_prompt = ""
-            ai_prompt_match = re.search(r'<summary>🤖 Prompt for AI Agents</summary>\s*\n\n```\n(.*?)\n```', body, re.DOTALL)
+            ai_prompt_match = re.search(
+                r"<summary>🤖 Prompt for AI Agents</summary>\s*\n\n```\n(.*?)\n```",
+                body,
+                re.DOTALL,
+            )
             if ai_prompt_match:
                 ai_prompt = ai_prompt_match.group(1).strip()
-            
-            file_groups[file_path].append({
-                'lines': str(line_num),
-                'title': title,
-                'description': main_content,
-                'code_diff': '',  # Inline comments don't have separate diffs
-                'ai_prompt': ai_prompt,
-                'source': 'inline',
-                'comment_type': comment_type
-            })
-    
+
+            file_groups[file_path].append(
+                {
+                    "lines": line_range,
+                    "title": title,
+                    "description": main_content,
+                    "code_diff": "",  # Inline comments don't have separate diffs
+                    "ai_prompt": ai_prompt,
+                    "source": "inline",
+                    "comment_type": comment_type,
+                }
+            )
+
     return file_groups
 
 
-def format_for_llm(coderabbit_reviews: List[Dict[str, Any]], inline_comments: List[Dict[str, Any]] = None, debug: bool = False, preamble: Optional[str] = None, include_resolved: bool = True) -> str:
+def format_for_llm(
+    coderabbit_reviews: List[Dict[str, Any]],
+    inline_comments: List[Dict[str, Any]] = None,
+    debug: bool = False,
+    preamble: Optional[str] = None,
+    include_resolved: bool = True,
+) -> str:
     """Format CodeRabbit review feedback organized by file for LLM consumption."""
     output = []
-    
+
     # Add custom preamble if provided
     if preamble:
         output.append(preamble)
         output.append("")
         output.append("=" * 60)
         output.append("")
-    
+
     output.append("# CodeRabbit Review Feedback")
     output.append("=" * 40)
     output.append("")
-    
+
     # Group all comments by file
-    file_groups = group_comments_by_file(coderabbit_reviews, inline_comments, debug, include_resolved)
-    
+    file_groups = group_comments_by_file(
+        coderabbit_reviews, inline_comments, debug, include_resolved
+    )
+
     if not file_groups:
         output.append("No actionable comments found.")
         return "\n".join(output)
-    
+
     # Add summary
     total_comments = sum(len(comments) for comments in file_groups.values())
     output.append(f"**Total files with feedback:** {len(file_groups)}")
     output.append(f"**Total comments:** {total_comments}")
     output.append("")
-    
+
     # Process each file
     for file_path in sorted(file_groups.keys()):
         comments = file_groups[file_path]
-        
+
         output.append(f"## {file_path}")
         output.append(f"**{len(comments)} suggestion(s)**")
         output.append("")
-        
+
         # Sort comments by priority: AI prompts first, then by line number
         def get_sort_key(comment):
             # Priority 1: Comments with AI prompts (highest priority)
-            has_ai_prompt = bool(comment.get('ai_prompt'))
-            
+            has_ai_prompt = bool(comment.get("ai_prompt"))
+
             # Priority 2: Line number (for logical code flow)
             line_num = 999
-            if comment['lines'].replace('-', '').isdigit():
-                line_num = int(comment['lines'].split('-')[0])
-                
+            lines = comment.get("lines", "")
+            if lines and lines.replace("-", "").isdigit():
+                line_num = int(lines.split("-")[0])
+
             # Return tuple: (ai_prompt_priority, line_number)
             # Lower numbers = higher priority, so AI prompts get 0, others get 1
             return (0 if has_ai_prompt else 1, line_num)
-        
+
         comments_sorted = sorted(comments, key=get_sort_key)
-        
+
         for i, comment in enumerate(comments_sorted, 1):
             # Add AI prompt indicator to title for high-priority items
-            title = comment['title']
-            if comment.get('ai_prompt'):
+            title = comment["title"]
+            if comment.get("ai_prompt"):
                 title = f"🤖 {title}"
-                
-            output.append(f"### {i}. Lines {comment['lines']}: {title}")
+
+            # Only include line numbers if they're meaningful (not empty or "0")
+            lines = comment.get("lines", "")
+            if lines and lines != "0":
+                output.append(f"### {i}. Lines {lines}: {title}")
+            else:
+                output.append(f"### {i}. {title}")
             output.append("")
-            
+
             # Show AI prompt, or fallback to description + diff
-            has_prompt = bool(comment.get('ai_prompt'))
-            has_diff = bool(comment.get('code_diff'))
-            
+            has_prompt = bool(comment.get("ai_prompt"))
+            has_diff = bool(comment.get("code_diff"))
+
             if debug:
-                output.append(f"<!-- DEBUG: has_prompt={has_prompt}, has_diff={has_diff}, source={comment.get('source')} -->")
-            
+                output.append(
+                    f"<!-- DEBUG: has_prompt={has_prompt}, has_diff={has_diff}, source={comment.get('source')} -->"
+                )
+
             if has_prompt:
                 if debug:
-                    output.append("<!-- DEBUG: Showing prompt only, skipping description and diff -->")
+                    output.append(
+                        "<!-- DEBUG: Showing prompt only, skipping description and diff -->"
+                    )
                 # AI prompt contains better explanation than description + diff
                 output.append("**Proposed prompt:**")
                 output.append("```")
-                output.append(comment['ai_prompt'])
+                output.append(comment["ai_prompt"])
                 output.append("```")
                 output.append("")
             else:
                 if debug:
-                    output.append("<!-- DEBUG: No prompt, showing description and diff -->")
-                
+                    output.append(
+                        "<!-- DEBUG: No prompt, showing description and diff -->"
+                    )
+
                 # Show description only if no AI prompt available
-                if comment['description'] and len(comment['description']) > 10:
-                    desc = comment['description']
-                    desc = re.sub(r'^_.*?_\s*', '', desc)  # Remove _⚠️ Potential issue_ etc
-                    desc = re.sub(r'\*\*.*?\*\*\s*', '', desc, count=1)  # Remove first **title** if duplicated
-                    desc = re.sub(r'Apply this diff:\s*', '', desc)
+                if comment["description"] and len(comment["description"]) > 10:
+                    desc = comment["description"]
+                    desc = re.sub(
+                        r"^_.*?_\s*", "", desc
+                    )  # Remove _⚠️ Potential issue_ etc
+                    desc = re.sub(
+                        r"\*\*.*?\*\*\s*", "", desc, count=1
+                    )  # Remove first **title** if duplicated
+                    desc = re.sub(r"Apply this diff:\s*", "", desc)
                     desc = desc.strip()
-                    
+
                     if desc and desc != title:
                         output.append(desc)
                         output.append("")
-                
+
                 # Show diff only if no AI prompt available
                 if has_diff:
                     output.append("```diff")
-                    output.append(comment['code_diff'])
+                    output.append(comment["code_diff"])
                     output.append("```")
                     output.append("")
-            
+
             if i < len(comments_sorted):
                 output.append("-" * 30)
                 output.append("")
-        
+
         output.append("=" * 60)
         output.append("")
-    
+
     return "\n".join(output)
 
 
@@ -718,12 +957,12 @@ to automatically apply code improvements, refactoring suggestions, and fixes.
         epilog="""
 EXAMPLES:
   %(prog)s https://github.com/owner/repo/pull/123
-  %(prog)s owner/repo/123  
+  %(prog)s owner/repo/123
   %(prog)s obra/lace/278 --all-reviews
 
 WHAT IT EXTRACTS:
   • Refactor suggestions with specific code diffs
-  • AI implementation instructions (🤖 prompts) with detailed steps  
+  • AI implementation instructions (🤖 prompts) with detailed steps
   • Nitpick comments and code quality improvements
   • File-organized feedback sorted by priority
   • Clean format without HTML artifacts or noise
@@ -747,104 +986,169 @@ CONFIGURATION:
   Create ~/.coderabbit-extractor with custom preamble text to prepend to output.
   Useful for framing feedback (e.g., critical evaluation prompts for AI agents).
         """,
-        formatter_class=argparse.RawDescriptionHelpFormatter
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    
-    parser.add_argument('pr_input', 
-                       help='GitHub PR URL or owner/repo/number format (e.g., "owner/repo/123")')
-    parser.add_argument('--include-resolved', 
-                       action='store_true',
-                       help='Include review suggestions that have been marked as resolved (default: filter them out)')
-    parser.add_argument('--all-reviews', 
-                       action='store_true',
-                       help='Extract all CodeRabbit reviews (default: latest only)')
-    parser.add_argument('--since-commit',
-                       metavar='SHA', 
-                       help='Extract reviews submitted after this commit SHA')
-    parser.add_argument('--debug',
-                       action='store_true',
-                       help='Show debug annotations in output to trace processing')
-    parser.add_argument('--version',
-                       action='version',
-                       version=f'%(prog)s {__version__}')
-    
+
+    parser.add_argument(
+        "pr_input",
+        help='GitHub PR URL or owner/repo/number format (e.g., "owner/repo/123")',
+    )
+    parser.add_argument(
+        "--include-resolved",
+        action="store_true",
+        help="Include review suggestions that have been marked as resolved (default: filter them out)",
+    )
+    parser.add_argument(
+        "--all-reviews",
+        action="store_true",
+        help="Extract all CodeRabbit reviews (default: latest only)",
+    )
+    parser.add_argument(
+        "--since-commit",
+        metavar="SHA",
+        help="Extract reviews submitted after this commit SHA",
+    )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Show debug annotations in output to trace processing",
+    )
+    parser.add_argument(
+        "--version", action="version", version=f"%(prog)s {__version__}"
+    )
+
     # Custom handling for no arguments to show helpful info
     if len(sys.argv) == 1:
         print("🤖 CodeRabbit Review Extractor")
         print("=" * 40)
         print()
         print("WHAT THIS DOES:")
-        print("  Converts CodeRabbit GitHub PR reviews into clean text for AI coding agents")
+        print(
+            "  Converts CodeRabbit GitHub PR reviews into clean text for AI coding agents"
+        )
         print("  (Claude, ChatGPT, etc.) to automatically apply code suggestions.")
         print()
         print("QUICK START:")
-        print("  python3 extract-coderabbit-feedback.py https://github.com/owner/repo/pull/123")
+        print(
+            "  python3 extract-coderabbit-feedback.py https://github.com/owner/repo/pull/123"
+        )
         print("  python3 extract-coderabbit-feedback.py owner/repo/123")
         print()
         print("For full help and options, run:")
         print("  python3 extract-coderabbit-feedback.py --help")
         sys.exit(1)
-    
+
     args = parser.parse_args()
-    
+
     try:
         pr_url = parse_pr_input(args.pr_input)
-        
+
         # Load custom preamble from dotfile
         preamble = load_preamble_config()
-        
+
         # Fetch both reviews and inline comments
         reviews = fetch_pr_reviews(pr_url)
         inline_comments = fetch_pr_inline_comments(pr_url)
-        
+
         # Extract PR info for GraphQL query
         try:
             owner, repo, pr_number = extract_pr_info_from_url(pr_url)
-            
+
             # Fetch review threads with resolution status via GraphQL
             review_threads = fetch_review_threads_graphql(owner, repo, pr_number)
-            
+
             if review_threads and not args.include_resolved:
                 # Filter out resolved threads (GitHub native conversation resolution)
                 original_thread_count = len(review_threads)
                 review_threads = filter_resolved_threads(review_threads)
                 filtered_thread_count = original_thread_count - len(review_threads)
                 if filtered_thread_count > 0:
-                    print(f"Filtered resolved review threads: {filtered_thread_count} resolved threads hidden", file=sys.stderr)
+                    print(
+                        f"Filtered resolved review threads: {filtered_thread_count} resolved threads hidden",
+                        file=sys.stderr,
+                    )
             elif review_threads:
-                print(f"Found {len(review_threads)} review threads (including resolved)", file=sys.stderr)
-                
+                print(
+                    f"Found {len(review_threads)} review threads (including resolved)",
+                    file=sys.stderr,
+                )
+
         except Exception as e:
-            print(f"Warning: Could not fetch review thread resolution data: {e}", file=sys.stderr)
+            print(
+                f"Warning: Could not fetch review thread resolution data: {e}",
+                file=sys.stderr,
+            )
             review_threads = []
-        
+
         coderabbit_reviews = extract_coderabbit_reviews(reviews)
         coderabbit_inline_comments = extract_coderabbit_inline_comments(inline_comments)
-        
+
+        # Build a set of existing comment identifiers for deduplication
+        # Use (path, line, body_start) tuple to identify duplicates
+        existing_comments = set()
+        for comment in coderabbit_inline_comments:
+            path = comment.get("path", "")
+            line = comment.get("original_line", 0)
+            body = comment.get("body", "")
+            # Use first 100 chars of body as identifier
+            body_start = body[:100] if body else ""
+            existing_comments.add((path, line, body_start))
+
         # Convert review threads to inline comment format and merge
         if review_threads:
             for thread in review_threads:
+                # Extract line range if available
+                start_line = thread.get("startLine")
+                end_line = thread.get("line")
+
+                # Determine the line value to use
+                if start_line and end_line and start_line != end_line:
+                    # Multi-line range
+                    line_value = end_line  # Use end line for sorting
+                elif end_line:
+                    # Single line
+                    line_value = end_line
+                else:
+                    line_value = 0
+
+                # Check for duplicates before adding
+                path = thread.get("path", "unknown")
+                body = thread.get("body", "")
+                body_start = body[:100] if body else ""
+                comment_id = (path, line_value, body_start)
+
+                # Skip if this comment already exists (from REST API)
+                if comment_id in existing_comments:
+                    continue
+
                 # Convert thread to inline comment format
                 inline_comment = {
-                    'id': thread['id'],
-                    'body': thread['body'],
-                    'user': {'login': 'coderabbitai[bot]'},
-                    'created_at': thread.get('createdAt', ''),  # Now includes timestamp from GraphQL
-                    'path': 'unknown',  # GraphQL doesn't provide file path in this query
-                    'original_line': 0,  # GraphQL doesn't provide line number in this query
-                    'html_url': f"https://github.com/{owner}/{repo}/pull/{pr_number}#discussion-{thread['id']}"
+                    "id": thread["id"],
+                    "body": body,
+                    "user": {"login": "coderabbitai[bot]"},
+                    "created_at": thread.get("createdAt", ""),
+                    "path": path,  # Use path from GraphQL
+                    "original_line": line_value,  # Use line from GraphQL
+                    "start_line": start_line,  # Store start_line for range information
+                    "html_url": f"https://github.com/{owner}/{repo}/pull/{pr_number}#discussion-{thread['id']}",
                 }
                 coderabbit_inline_comments.append(inline_comment)
-        
+                existing_comments.add(comment_id)  # Add to set to track
+
         # Filter out resolved comments if not including them
         if not args.include_resolved:
             original_count = len(coderabbit_inline_comments)
-            coderabbit_inline_comments = filter_resolved_comments(coderabbit_inline_comments)
+            coderabbit_inline_comments = filter_resolved_comments(
+                coderabbit_inline_comments
+            )
             filtered_count = original_count - len(coderabbit_inline_comments)
             if filtered_count > 0:
-                print(f"Filtered resolved comments: {filtered_count} resolved comments hidden", file=sys.stderr)
+                print(
+                    f"Filtered resolved comments: {filtered_count} resolved comments hidden",
+                    file=sys.stderr,
+                )
         # Note: Review-level filtering is handled in group_comments_by_file()
-        
+
         # Filter reviews based on options
         if not args.all_reviews and not args.since_commit:
             # Default: latest review with actual content
@@ -852,67 +1156,95 @@ CONFIGURATION:
                 # Find the latest review with substantial content (not just continuation)
                 latest_review = None
                 for review in reversed(coderabbit_reviews):
-                    body = review.get('body', '')
+                    body = review.get("body", "")
                     # Skip continuation reviews that have minimal content
-                    if (len(body) > 100 and 
-                        'Actionable comments posted:' in body and
-                        not body.strip().startswith('**Review continued from previous batch')):
+                    if (
+                        len(body) > 100
+                        and "Actionable comments posted:" in body
+                        and not body.strip().startswith(
+                            "**Review continued from previous batch"
+                        )
+                    ):
                         latest_review = review
                         break
-                
+
                 # Fallback to chronologically latest if no substantial review found
                 if not latest_review:
                     latest_review = coderabbit_reviews[-1]
-                    
+
                 coderabbit_reviews = [latest_review]
-                
+
                 # Filter inline comments to only those posted after the most recent commit
                 latest_commit_time = fetch_latest_commit_time(pr_url)
                 if latest_commit_time and coderabbit_inline_comments:
-                    from datetime import datetime, timedelta
-                    
+                    from datetime import datetime
+
                     try:
                         # Parse ISO format timestamps (GitHub API standard)
-                        commit_dt = datetime.fromisoformat(latest_commit_time.replace('Z', '+00:00'))
-                        
+                        commit_dt = datetime.fromisoformat(
+                            latest_commit_time.replace("Z", "+00:00")
+                        )
+
                         filtered_inline = []
                         for comment in coderabbit_inline_comments:
-                            comment_time = comment.get('created_at', '')
+                            comment_time = comment.get("created_at", "")
                             if comment_time:
-                                comment_dt = datetime.fromisoformat(comment_time.replace('Z', '+00:00'))
+                                comment_dt = datetime.fromisoformat(
+                                    comment_time.replace("Z", "+00:00")
+                                )
                                 # Include comments posted after the latest commit
                                 if comment_dt > commit_dt:
                                     filtered_inline.append(comment)
-                        
+
                         original_count = len(coderabbit_inline_comments)
                         coderabbit_inline_comments = filtered_inline
                         if original_count != len(filtered_inline):
-                            print(f"Filtered inline comments: {original_count} → {len(filtered_inline)} (after latest commit)", file=sys.stderr)
-                            
+                            print(
+                                f"Filtered inline comments: {original_count} → {len(filtered_inline)} (after latest commit)",
+                                file=sys.stderr,
+                            )
+
                     except Exception as e:
-                        print(f"Warning: Could not filter inline comments by commit time: {e}", file=sys.stderr)
+                        print(
+                            f"Warning: Could not filter inline comments by commit time: {e}",
+                            file=sys.stderr,
+                        )
         elif args.since_commit:
             # Filter reviews submitted after the specified commit
             # This would require additional logic to compare timestamps with commit dates
             print("--since-commit option not yet implemented", file=sys.stderr)
             sys.exit(1)
-        
+
         if not coderabbit_reviews and not coderabbit_inline_comments:
-            print("No CodeRabbit reviews or comments found in this PR.", file=sys.stderr)
+            print(
+                "No CodeRabbit reviews or comments found in this PR.", file=sys.stderr
+            )
             sys.exit(1)
-        
+
         # Show processing info
         if len(coderabbit_reviews) > 1:
-            print(f"Processing {len(coderabbit_reviews)} CodeRabbit reviews...", file=sys.stderr)
+            print(
+                f"Processing {len(coderabbit_reviews)} CodeRabbit reviews...",
+                file=sys.stderr,
+            )
         elif len(coderabbit_reviews) == 1:
-            print(f"Processing latest CodeRabbit review...", file=sys.stderr)
-            
+            print("Processing latest CodeRabbit review...", file=sys.stderr)
+
         if coderabbit_inline_comments:
-            print(f"Found {len(coderabbit_inline_comments)} inline comments", file=sys.stderr)
-        
-        formatted_output = format_for_llm(coderabbit_reviews, coderabbit_inline_comments, args.debug, preamble, args.include_resolved)
+            print(
+                f"Found {len(coderabbit_inline_comments)} inline comments",
+                file=sys.stderr,
+            )
+
+        formatted_output = format_for_llm(
+            coderabbit_reviews,
+            coderabbit_inline_comments,
+            args.debug,
+            preamble,
+            args.include_resolved,
+        )
         print(formatted_output)
-        
+
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)

--- a/extract-coderabbit-feedback.py
+++ b/extract-coderabbit-feedback.py
@@ -54,6 +54,29 @@ def parse_pr_input(input_str: str) -> str:
     )
 
 
+def get_current_branch_pr() -> Optional[str]:
+    """Get the PR URL for the current branch using gh CLI.
+
+    Returns None if no PR is found for the current branch.
+    """
+    try:
+        # GH_PAGER= prefix disables pager for JSON output
+        result = subprocess.run(
+            ["gh", "pr", "view", "--json", "url"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        data = json.loads(result.stdout)
+        return data.get("url")
+    except subprocess.CalledProcessError:
+        # No PR found for current branch
+        return None
+    except json.JSONDecodeError:
+        # Error parsing JSON response
+        return None
+
+
 def extract_pr_info_from_url(pr_url: str) -> Tuple[str, str, int]:
     """Extract owner, repo, and PR number from GitHub PR URL."""
     # Parse URL like https://github.com/owner/repo/pull/123
@@ -512,7 +535,10 @@ def parse_review_sections(body: str, debug: bool = False) -> Dict[str, Any]:
     details_elements = soup.find_all("details")
 
     if debug:
-        print(f"DEBUG: Found {len(details_elements)} <details> elements in review body", file=sys.stderr)
+        print(
+            f"DEBUG: Found {len(details_elements)} <details> elements in review body",
+            file=sys.stderr,
+        )
 
     for details in details_elements:
         summary = details.find("summary")
@@ -524,7 +550,10 @@ def parse_review_sections(body: str, debug: bool = False) -> Dict[str, Any]:
         # Check for outside diff range comments (avoid emoji dependency)
         if "Outside diff range comments" in summary_text:
             if debug:
-                print(f"DEBUG: Found 'Outside diff range comments' section", file=sys.stderr)
+                print(
+                    f"DEBUG: Found 'Outside diff range comments' section",
+                    file=sys.stderr,
+                )
 
             # Extract count from summary text
             count_match = re.search(r"\((\d+)\)", summary_text)
@@ -539,11 +568,20 @@ def parse_review_sections(body: str, debug: bool = False) -> Dict[str, Any]:
                         "content": content,
                     }
                     if debug:
-                        print(f"DEBUG: Extracted {count} outside diff comments, content length: {len(content)}", file=sys.stderr)
+                        print(
+                            f"DEBUG: Extracted {count} outside diff comments, content length: {len(content)}",
+                            file=sys.stderr,
+                        )
                 elif debug:
-                    print(f"DEBUG: No blockquote found in outside diff section", file=sys.stderr)
+                    print(
+                        f"DEBUG: No blockquote found in outside diff section",
+                        file=sys.stderr,
+                    )
             elif debug:
-                print(f"DEBUG: No count match found in summary: {summary_text}", file=sys.stderr)
+                print(
+                    f"DEBUG: No count match found in summary: {summary_text}",
+                    file=sys.stderr,
+                )
 
         # Check for nitpick comments or duplicate comments
         elif "Nitpick comments" in summary_text or "Duplicate comments" in summary_text:
@@ -597,7 +635,10 @@ def parse_file_level_comments(
     comments = []
 
     if debug:
-        print(f"DEBUG: parse_file_level_comments received content length: {len(content)}", file=sys.stderr)
+        print(
+            f"DEBUG: parse_file_level_comments received content length: {len(content)}",
+            file=sys.stderr,
+        )
         print(f"DEBUG: Content preview: {content[:200]}...", file=sys.stderr)
 
     # Use regex to find file sections instead of BeautifulSoup to avoid HTML corruption
@@ -622,7 +663,7 @@ def parse_file_level_comments(
         file_content = html.unescape(file_content)
 
         # Remove blockquote markers (> at start of lines)
-        file_content = re.sub(r'^>\s*', '', file_content, flags=re.MULTILINE)
+        file_content = re.sub(r"^>\s*", "", file_content, flags=re.MULTILINE)
 
         # Now parse line comments within this file content
         # Find line comment patterns: `16-24`: **Title**
@@ -699,7 +740,7 @@ def parse_file_level_comments(
 
 def group_comments_by_file(
     coderabbit_reviews: List[Dict[str, Any]],
-    inline_comments: List[Dict[str, Any]] = None,
+    inline_comments: List[Dict[str, Any]] | None = None,
     debug: bool = False,
     include_resolved: bool = True,
 ) -> Dict[str, List[Dict[str, Any]]]:
@@ -733,7 +774,10 @@ def group_comments_by_file(
                 sections["outside_diff_comments"]["content"], debug
             )
             if debug:
-                print(f"DEBUG: Parsed {len(outside_comments)} outside diff comments", file=sys.stderr)
+                print(
+                    f"DEBUG: Parsed {len(outside_comments)} outside diff comments",
+                    file=sys.stderr,
+                )
             for comment in outside_comments:
                 file_path = comment["file"]
                 if file_path not in file_groups:
@@ -741,7 +785,10 @@ def group_comments_by_file(
                 comment["source"] = "outside_diff"
                 file_groups[file_path].append(comment)
         elif debug:
-            print("DEBUG: No 'outside_diff_comments' key found in sections", file=sys.stderr)
+            print(
+                "DEBUG: No 'outside_diff_comments' key found in sections",
+                file=sys.stderr,
+            )
 
         # Add nitpick comments
         if "nitpick_comments" in sections:
@@ -842,7 +889,7 @@ def group_comments_by_file(
 
 def format_for_llm(
     coderabbit_reviews: List[Dict[str, Any]],
-    inline_comments: List[Dict[str, Any]] = None,
+    inline_comments: List[Dict[str, Any]] | None = None,
     debug: bool = False,
     preamble: Optional[str] = None,
     include_resolved: bool = True,
@@ -852,13 +899,14 @@ def format_for_llm(
 
     # Add custom preamble if provided
     if preamble:
+        output.append("")
         output.append(preamble)
         output.append("")
-        output.append("=" * 60)
+        output.append("=" * 10)
         output.append("")
 
-    output.append("# CodeRabbit Review Feedback")
-    output.append("=" * 40)
+    output.append("# Review Feedback")
+    output.append("=" * 5)
     output.append("")
 
     # Group all comments by file
@@ -968,7 +1016,7 @@ def format_for_llm(
                 output.append("-" * 30)
                 output.append("")
 
-        output.append("=" * 60)
+        output.append("=" * 10)
         output.append("")
 
     return "\n".join(output)
@@ -988,6 +1036,10 @@ to automatically apply code improvements, refactoring suggestions, and fixes.
         """.strip(),
         epilog="""
 EXAMPLES:
+  # Auto-detect PR for current branch
+  %(prog)s
+
+  # Explicit PR specification
   %(prog)s https://github.com/owner/repo/pull/123
   %(prog)s owner/repo/123
   %(prog)s obra/lace/278 --all-reviews
@@ -1007,8 +1059,9 @@ HOW IT WORKS:
   5. Outputs clean text ready for LLM consumption
 
 DEFAULT BEHAVIOR:
-  Processes only the LATEST CodeRabbit review to avoid overwhelming output.
-  Use --all-reviews for PRs with multiple review iterations if needed.
+  • Auto-detects PR for current branch when no PR argument provided
+  • Processes only the LATEST CodeRabbit review to avoid overwhelming output
+  • Use --all-reviews for PRs with multiple review iterations if needed
 
 REQUIREMENTS:
   • GitHub CLI (gh) installed and authenticated
@@ -1023,7 +1076,8 @@ CONFIGURATION:
 
     parser.add_argument(
         "pr_input",
-        help='GitHub PR URL or owner/repo/number format (e.g., "owner/repo/123")',
+        nargs="?",
+        help='GitHub PR URL or owner/repo/number format (e.g., "owner/repo/123"). If omitted, uses the PR for the current branch.',
     )
     parser.add_argument(
         "--include-resolved",
@@ -1049,31 +1103,36 @@ CONFIGURATION:
         "--version", action="version", version=f"%(prog)s {__version__}"
     )
 
-    # Custom handling for no arguments to show helpful info
-    if len(sys.argv) == 1:
-        print("🤖 CodeRabbit Review Extractor")
-        print("=" * 40)
-        print()
-        print("WHAT THIS DOES:")
-        print(
-            "  Converts CodeRabbit GitHub PR reviews into clean text for AI coding agents"
-        )
-        print("  (Claude, ChatGPT, etc.) to automatically apply code suggestions.")
-        print()
-        print("QUICK START:")
-        print(
-            "  python3 extract-coderabbit-feedback.py https://github.com/owner/repo/pull/123"
-        )
-        print("  python3 extract-coderabbit-feedback.py owner/repo/123")
-        print()
-        print("For full help and options, run:")
-        print("  python3 extract-coderabbit-feedback.py --help")
-        sys.exit(1)
-
     args = parser.parse_args()
 
     try:
-        pr_url = parse_pr_input(args.pr_input)
+        # If no PR input provided, try to get PR for current branch
+        if args.pr_input is None:
+            pr_url = get_current_branch_pr()
+            if pr_url is None:
+                print("❌ No PR found for the current branch.", file=sys.stderr)
+                print(file=sys.stderr)
+                print("To use this tool, either:", file=sys.stderr)
+                print(
+                    "  1. Run it from a branch that has an associated PR, or",
+                    file=sys.stderr,
+                )
+                print("  2. Provide a PR explicitly:", file=sys.stderr)
+                print(file=sys.stderr)
+                print(
+                    "     coderabbit-extract https://github.com/owner/repo/pull/123",
+                    file=sys.stderr,
+                )
+                print("     coderabbit-extract owner/repo/123", file=sys.stderr)
+                print(file=sys.stderr)
+                print("For full help and options, run:", file=sys.stderr)
+                print("  coderabbit-extract --help", file=sys.stderr)
+                sys.exit(1)
+            # Assert for type checker - we've already checked pr_url is not None
+            assert pr_url is not None
+            print(f"📌 Using PR for current branch: {pr_url}", file=sys.stderr)
+        else:
+            pr_url = parse_pr_input(args.pr_input)
 
         # Load custom preamble from dotfile
         preamble = load_preamble_config()
@@ -1256,11 +1315,11 @@ CONFIGURATION:
         # Show processing info
         if len(coderabbit_reviews) > 1:
             print(
-                f"Processing {len(coderabbit_reviews)} CodeRabbit reviews...",
+                f"Processing {len(coderabbit_reviews)} reviews...",
                 file=sys.stderr,
             )
         elif len(coderabbit_reviews) == 1:
-            print("Processing latest CodeRabbit review...", file=sys.stderr)
+            print("Processing latest review...", file=sys.stderr)
 
         if coderabbit_inline_comments:
             print(

--- a/extract-coderabbit-feedback.py
+++ b/extract-coderabbit-feedback.py
@@ -495,7 +495,7 @@ def extract_prompt_for_ai_agents(body: str) -> List[str]:
 # Removed unused functions - now using parse_review_sections instead
 
 
-def parse_review_sections(body: str) -> Dict[str, Any]:
+def parse_review_sections(body: str, debug: bool = False) -> Dict[str, Any]:
     """Parse different sections from CodeRabbit review body using HTML parsing."""
     sections = {}
 
@@ -511,6 +511,9 @@ def parse_review_sections(body: str) -> Dict[str, Any]:
     # Find sections by looking for <details> elements with specific summary text
     details_elements = soup.find_all("details")
 
+    if debug:
+        print(f"DEBUG: Found {len(details_elements)} <details> elements in review body", file=sys.stderr)
+
     for details in details_elements:
         summary = details.find("summary")
         if not summary:
@@ -520,6 +523,9 @@ def parse_review_sections(body: str) -> Dict[str, Any]:
 
         # Check for outside diff range comments (avoid emoji dependency)
         if "Outside diff range comments" in summary_text:
+            if debug:
+                print(f"DEBUG: Found 'Outside diff range comments' section", file=sys.stderr)
+
             # Extract count from summary text
             count_match = re.search(r"\((\d+)\)", summary_text)
             if count_match:
@@ -532,6 +538,12 @@ def parse_review_sections(body: str) -> Dict[str, Any]:
                         "count": count,
                         "content": content,
                     }
+                    if debug:
+                        print(f"DEBUG: Extracted {count} outside diff comments, content length: {len(content)}", file=sys.stderr)
+                elif debug:
+                    print(f"DEBUG: No blockquote found in outside diff section", file=sys.stderr)
+            elif debug:
+                print(f"DEBUG: No count match found in summary: {summary_text}", file=sys.stderr)
 
         # Check for nitpick comments or duplicate comments
         elif "Nitpick comments" in summary_text or "Duplicate comments" in summary_text:
@@ -584,6 +596,10 @@ def parse_file_level_comments(
     """Parse individual file-level comments from section content, avoiding HTML corruption."""
     comments = []
 
+    if debug:
+        print(f"DEBUG: parse_file_level_comments received content length: {len(content)}", file=sys.stderr)
+        print(f"DEBUG: Content preview: {content[:200]}...", file=sys.stderr)
+
     # Use regex to find file sections instead of BeautifulSoup to avoid HTML corruption
     # Pattern: <summary>filename (count)</summary><blockquote>content</blockquote></details>
     file_pattern = r"<summary>([^<]+?)\s*\((\d+)\)</summary><blockquote>(.*?)</blockquote></details>"
@@ -602,14 +618,21 @@ def parse_file_level_comments(
             3
         )  # Raw blockquote content, not parsed by BeautifulSoup
 
+        # HTML unescape the content (e.g., &gt; -> >, &lt; -> <)
+        file_content = html.unescape(file_content)
+
+        # Remove blockquote markers (> at start of lines)
+        file_content = re.sub(r'^>\s*', '', file_content, flags=re.MULTILINE)
+
         # Now parse line comments within this file content
         # Find line comment patterns: `16-24`: **Title**
-        line_pattern = r"`([^`]+)`:\s*\*\*(.*?)\*\*\s*\n\n(.*?)(?=\n\n`[^`]+`:\s*\*\*|\n\n---|\n\n</blockquote>|$)"
+        # Allow for either one or two newlines after the title
+        line_pattern = r"`([^`]+)`:\s*\*\*(.*?)\*\*\s*\n+(.*?)(?=\n+`[^`]+`:\s*\*\*|\n+---|\n+</blockquote>|\n+Also applies to:|$)"
         line_matches = list(re.finditer(line_pattern, file_content, re.DOTALL))
 
         if debug:
             print(
-                f"DEBUG: File {file_path} has {len(line_matches)} line comments",
+                f"DEBUG: File {file_path} has {len(line_matches)} line comments (expected {comment_count})",
                 file=sys.stderr,
             )
 
@@ -697,19 +720,28 @@ def group_comments_by_file(
                     file=sys.stderr,
                 )
 
-        sections = parse_review_sections(review_body)
+        sections = parse_review_sections(review_body, debug)
 
         # Add outside diff comments
         if "outside_diff_comments" in sections:
+            if debug:
+                print(
+                    f"DEBUG: Processing {sections['outside_diff_comments']['count']} outside diff comments",
+                    file=sys.stderr,
+                )
             outside_comments = parse_file_level_comments(
                 sections["outside_diff_comments"]["content"], debug
             )
+            if debug:
+                print(f"DEBUG: Parsed {len(outside_comments)} outside diff comments", file=sys.stderr)
             for comment in outside_comments:
                 file_path = comment["file"]
                 if file_path not in file_groups:
                     file_groups[file_path] = []
                 comment["source"] = "outside_diff"
                 file_groups[file_path].append(comment)
+        elif debug:
+            print("DEBUG: No 'outside_diff_comments' key found in sections", file=sys.stderr)
 
         # Add nitpick comments
         if "nitpick_comments" in sections:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,31 +7,25 @@ name = "coderabbit-review-extractor"
 version = "1.0.0"
 description = "Extract CodeRabbit GitHub PR reviews for AI coding agent consumption"
 readme = "README.md"
-license = {text = "MIT"}
-authors = [
-    {name = "Jesse Vincent", email = "jesse@fsck.com"}
-]
+license = { text = "MIT" }
+authors = [{ name = "Jesse Vincent", email = "jesse@fsck.com" }]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.6",
-    "Programming Language :: Python :: 3.7", 
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Code Generators",
     "Topic :: Software Development :: Quality Assurance",
-    "Topic :: Text Processing :: Markup :: HTML"
+    "Topic :: Text Processing :: Markup :: HTML",
 ]
 keywords = ["coderabbit", "code-review", "ai", "llm", "github", "automation"]
-requires-python = ">=3.6"
-dependencies = [
-    "beautifulsoup4>=4.9.0"
-]
+requires-python = ">=3.10"
+dependencies = ["beautifulsoup4>=4.9.0"]
 
 [project.urls]
 Homepage = "https://github.com/obra/coderabbit-review-helper"
@@ -44,9 +38,5 @@ coderabbit-extract = "coderabbit_review_extractor:main"
 [tool.setuptools]
 py-modules = ["extract-coderabbit-feedback"]
 
-[project.optional-dependencies]
-dev = [
-    "pytest>=6.0",
-    "black",
-    "flake8"
-]
+[dependency-groups]
+dev = ["ruff>=0.14.4"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools>=45", "wheel"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [project]
 name = "coderabbit-review-extractor"
@@ -33,10 +33,10 @@ Repository = "https://github.com/obra/coderabbit-review-helper"
 Issues = "https://github.com/obra/coderabbit-review-helper/issues"
 
 [project.scripts]
-coderabbit-extract = "coderabbit_review_extractor:main"
+coderabbit-extract = "extract_coderabbit_feedback:main"
 
-[tool.setuptools]
-py-modules = ["extract-coderabbit-feedback"]
+[tool.hatch.build.targets.wheel.force-include]
+"extract-coderabbit-feedback.py" = "extract_coderabbit_feedback.py"
 
 [dependency-groups]
 dev = ["ruff>=0.14.4"]

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,79 @@
+version = 1
+revision = 3
+requires-python = ">=3.10"
+
+[[package]]
+name = "beautifulsoup4"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/e9/df2358efd7659577435e2177bfa69cba6c33216681af51a707193dec162a/beautifulsoup4-4.14.2.tar.gz", hash = "sha256:2a98ab9f944a11acee9cc848508ec28d9228abfd522ef0fad6a02a72e0ded69e", size = 625822, upload-time = "2025-09-29T10:05:42.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/fe/3aed5d0be4d404d12d36ab97e2f1791424d9ca39c2f754a6285d59a3b01d/beautifulsoup4-4.14.2-py3-none-any.whl", hash = "sha256:5ef6fa3a8cbece8488d66985560f97ed091e22bbc4e9c2338508a9d5de6d4515", size = 106392, upload-time = "2025-09-29T10:05:43.771Z" },
+]
+
+[[package]]
+name = "coderabbit-review-extractor"
+version = "1.0.0"
+source = { editable = "." }
+dependencies = [
+    { name = "beautifulsoup4" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "beautifulsoup4", specifier = ">=4.9.0" }]
+
+[package.metadata.requires-dev]
+dev = [{ name = "ruff", specifier = ">=0.14.4" }]
+
+[[package]]
+name = "ruff"
+version = "0.14.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/55/cccfca45157a2031dcbb5a462a67f7cf27f8b37d4b3b1cd7438f0f5c1df6/ruff-0.14.4.tar.gz", hash = "sha256:f459a49fe1085a749f15414ca76f61595f1a2cc8778ed7c279b6ca2e1fd19df3", size = 5587844, upload-time = "2025-11-06T22:07:45.033Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/b9/67240254166ae1eaa38dec32265e9153ac53645a6c6670ed36ad00722af8/ruff-0.14.4-py3-none-linux_armv6l.whl", hash = "sha256:e6604613ffbcf2297cd5dcba0e0ac9bd0c11dc026442dfbb614504e87c349518", size = 12606781, upload-time = "2025-11-06T22:07:01.841Z" },
+    { url = "https://files.pythonhosted.org/packages/46/c8/09b3ab245d8652eafe5256ab59718641429f68681ee713ff06c5c549f156/ruff-0.14.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:d99c0b52b6f0598acede45ee78288e5e9b4409d1ce7f661f0fa36d4cbeadf9a4", size = 12946765, upload-time = "2025-11-06T22:07:05.858Z" },
+    { url = "https://files.pythonhosted.org/packages/14/bb/1564b000219144bf5eed2359edc94c3590dd49d510751dad26202c18a17d/ruff-0.14.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:9358d490ec030f1b51d048a7fd6ead418ed0826daf6149e95e30aa67c168af33", size = 11928120, upload-time = "2025-11-06T22:07:08.023Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/92/d5f1770e9988cc0742fefaa351e840d9aef04ec24ae1be36f333f96d5704/ruff-0.14.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:81b40d27924f1f02dfa827b9c0712a13c0e4b108421665322218fc38caf615c2", size = 12370877, upload-time = "2025-11-06T22:07:10.015Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/29/e9282efa55f1973d109faf839a63235575519c8ad278cc87a182a366810e/ruff-0.14.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f5e649052a294fe00818650712083cddc6cc02744afaf37202c65df9ea52efa5", size = 12408538, upload-time = "2025-11-06T22:07:13.085Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/01/930ed6ecfce130144b32d77d8d69f5c610e6d23e6857927150adf5d7379a/ruff-0.14.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:aa082a8f878deeba955531f975881828fd6afd90dfa757c2b0808aadb437136e", size = 13141942, upload-time = "2025-11-06T22:07:15.386Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/46/a9c89b42b231a9f487233f17a89cbef9d5acd538d9488687a02ad288fa6b/ruff-0.14.4-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:1043c6811c2419e39011890f14d0a30470f19d47d197c4858b2787dfa698f6c8", size = 14544306, upload-time = "2025-11-06T22:07:17.631Z" },
+    { url = "https://files.pythonhosted.org/packages/78/96/9c6cf86491f2a6d52758b830b89b78c2ae61e8ca66b86bf5a20af73d20e6/ruff-0.14.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a9f3a936ac27fb7c2a93e4f4b943a662775879ac579a433291a6f69428722649", size = 14210427, upload-time = "2025-11-06T22:07:19.832Z" },
+    { url = "https://files.pythonhosted.org/packages/71/f4/0666fe7769a54f63e66404e8ff698de1dcde733e12e2fd1c9c6efb689cb5/ruff-0.14.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:95643ffd209ce78bc113266b88fba3d39e0461f0cbc8b55fb92505030fb4a850", size = 13658488, upload-time = "2025-11-06T22:07:22.32Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/79/6ad4dda2cfd55e41ac9ed6d73ef9ab9475b1eef69f3a85957210c74ba12c/ruff-0.14.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:456daa2fa1021bc86ca857f43fe29d5d8b3f0e55e9f90c58c317c1dcc2afc7b5", size = 13354908, upload-time = "2025-11-06T22:07:24.347Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/60/f0b6990f740bb15c1588601d19d21bcc1bd5de4330a07222041678a8e04f/ruff-0.14.4-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:f911bba769e4a9f51af6e70037bb72b70b45a16db5ce73e1f72aefe6f6d62132", size = 13587803, upload-time = "2025-11-06T22:07:26.327Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/da/eaaada586f80068728338e0ef7f29ab3e4a08a692f92eb901a4f06bbff24/ruff-0.14.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:76158a7369b3979fa878612c623a7e5430c18b2fd1c73b214945c2d06337db67", size = 12279654, upload-time = "2025-11-06T22:07:28.46Z" },
+    { url = "https://files.pythonhosted.org/packages/66/d4/b1d0e82cf9bf8aed10a6d45be47b3f402730aa2c438164424783ac88c0ed/ruff-0.14.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:f3b8f3b442d2b14c246e7aeca2e75915159e06a3540e2f4bed9f50d062d24469", size = 12357520, upload-time = "2025-11-06T22:07:31.468Z" },
+    { url = "https://files.pythonhosted.org/packages/04/f4/53e2b42cc82804617e5c7950b7079d79996c27e99c4652131c6a1100657f/ruff-0.14.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c62da9a06779deecf4d17ed04939ae8b31b517643b26370c3be1d26f3ef7dbde", size = 12719431, upload-time = "2025-11-06T22:07:33.831Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/94/80e3d74ed9a72d64e94a7b7706b1c1ebaa315ef2076fd33581f6a1cd2f95/ruff-0.14.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5a443a83a1506c684e98acb8cb55abaf3ef725078be40237463dae4463366349", size = 13464394, upload-time = "2025-11-06T22:07:35.905Z" },
+    { url = "https://files.pythonhosted.org/packages/54/1a/a49f071f04c42345c793d22f6cf5e0920095e286119ee53a64a3a3004825/ruff-0.14.4-py3-none-win32.whl", hash = "sha256:643b69cb63cd996f1fc7229da726d07ac307eae442dd8974dbc7cf22c1e18fff", size = 12493429, upload-time = "2025-11-06T22:07:38.43Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/22/e58c43e641145a2b670328fb98bc384e20679b5774258b1e540207580266/ruff-0.14.4-py3-none-win_amd64.whl", hash = "sha256:26673da283b96fe35fa0c939bf8411abec47111644aa9f7cfbd3c573fb125d2c", size = 13635380, upload-time = "2025-11-06T22:07:40.496Z" },
+    { url = "https://files.pythonhosted.org/packages/30/bd/4168a751ddbbf43e86544b4de8b5c3b7be8d7167a2a5cb977d274e04f0a1/ruff-0.14.4-py3-none-win_arm64.whl", hash = "sha256:dd09c292479596b0e6fec8cd95c65c3a6dc68e9ad17b8f2382130f87ff6a75bb", size = 12663065, upload-time = "2025-11-06T22:07:42.603Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/e6/21ccce3262dd4889aa3332e5a119a3491a95e8f60939870a3a035aabac0d/soupsieve-2.8.tar.gz", hash = "sha256:e2dd4a40a628cb5f28f6d4b0db8800b8f581b65bb380b97de22ba5ca8d72572f", size = 103472, upload-time = "2025-08-27T15:39:51.78Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/a0/bb38d3b76b8cae341dad93a2dd83ab7462e6dbcdd84d43f54ee60a8dc167/soupsieve-2.8-py3-none-any.whl", hash = "sha256:0cc76456a30e20f5d7f2e14a98a4ae2ee4e5abdc7c5ea0aafe795f344bc7984c", size = 36679, upload-time = "2025-08-27T15:39:50.179Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]


### PR DESCRIPTION
NOTE: this contains the changes from #2 too as I couldn't find a way to diff compared to that

## Motivation and Context

I wanted to be able to build the library with `uv` and install as a tool (`uv tool` / `uvx`) so updated some of the project build settings.

I also realised that [gh pr view](https://cli.github.com/manual/gh_pr_view) can return the PR related to the current branch so made the default behaviour to try to detect it.

Don't think this is pushed to pypi yet? If it was, after this change people could do:

```sh
uvx coderabbit-extract
```

And if there's a PR off their current branch get the CR review content right away!

## How Has This Been Tested?

I tested with 2 PRs in different repos

## Breaking Changes

Possibly for `pip` based workflow, I haven't tested

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auto-detect PR capability when no explicit input provided
  * Enhanced extraction with improved comment parsing and deduplication
  * Custom preambles for AI critical thinking integration

* **Documentation**
  * Expanded installation guidance with multiple setup options
  * Added integration examples for AI assistants
  * Enhanced usage patterns and output format descriptions

* **Chores**
  * Migrated build system to Hatchling
  * Updated Python version support (3.10+; added 3.13–3.14)
  * Updated console script naming

<!-- end of auto-generated comment: release notes by coderabbit.ai -->